### PR TITLE
Now correctly using the API base URL, when defined, addressing #16

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,7 +41,13 @@ func main() {
 	owner, repo := ownerAndRepo(conf.RepositoryURL)
 	commentBody := conf.Body
 
-	githubClient := github.NewClient(string(conf.AuthToken))
+	var githubClient *github.GithubClient
+
+	if conf.APIBaseURL == "" {
+		githubClient = github.NewClient(string(conf.AuthToken))
+	} else {
+		githubClient = github.NewEnterpriseClient(conf.APIBaseURL, string(conf.AuthToken))
+	}
 
 	// if tag is set, try to find and update existing comment
 	if conf.UpdateCommentTag != "" {


### PR DESCRIPTION
## Problem
APIBaseURL not being considered, as per [this issue in the upstream](https://github.com/kvvzr/bitrise-step-comment-on-github-pull-request/issues/16)

## Solution
Create a new enterprise client, instead of a regular client (github.com) when the APIBaseURL is defined