### PR TITLE
Modified: Comment leading and trailing characters

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ func ownerAndRepo(url string) (string, string) {
 
 // wraps the tag in some special characters to avoid colliding with random text
 func decoratedTag(tag string) string {
-	return fmt.Sprintf("-- %s --", tag)
+	return fmt.Sprintf("<!-- %s -->", tag)
 }
 
 func main() {


### PR DESCRIPTION
### Description
The comment tag that a user fills get wrapped with double dashes. 
This looks odd on the PR and prevent the user from hiding the comment tag.

In this PR I modified the comment tag leading and trailing characters to a hidden markup characters. 
This way the tag can be hidden while keeping the logic to update the PR's comment if a tag already exist.

If needed we may instead replace the current characters with an open angle brackets e.g. **<>** and let the user decide if they want to hide the tag by adding the required characters or not. 